### PR TITLE
Improve PHP version tests on Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
+  - 7.2
+  - 7.3
+  - 7.4
 
 install:
   - composer self-update
-  - composer install --dev
+  - composer install
 
 before_script:
   - phpenv rehash

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         }
     },
     "require": {
+        "php": ">=7.2.0",
         "cakephp/cakephp": "^4.0",
         "cakephp/plugin-installer": "*",
         "geshi/geshi": "^1.0"


### PR DESCRIPTION
# Changed log

- Since this PHP package requires `cakephp/cakephp:^4.0` version, it should require `php-7.2` version at least.
- Letting the PHP version tests are changed  into `7.2`, `7.3` and `7.4` versions during Travis CI build.
- Remove `--dev` option for `composer install` because it's deprecated:

```
You are using the deprecated option "--dev". It has no effect and will break in Composer 3.
```